### PR TITLE
Changed cookie attributes

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,7 +38,7 @@ env.config({ path: path.resolve(process.cwd(), '..', '.env'), example: path.reso
       maxAge: 1000 * 60 * 60 * 24 * 365 * 10,
       httpOnly: true,
       secure: __PROD__,
-      sameSite: 'lax'
+      sameSite: 'none'
     }
   }))
 


### PR DESCRIPTION
Apollo Playground should now work correctly with cookies. Just make sure you set Include Cookies to true in the connection options of Apollo Playground.