### PR TITLE
Implemented searchable selection input with modal

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -17,5 +17,8 @@
     "@typescript-eslint/no-unused-vars": "error",
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": ["error"]
+  },
+  "globals": {
+    "JSX": "readonly"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "11.1.5",
         "formik": "^2.2.9",
         "framer-motion": "^4.0.3",
+        "fuzzysort": "^1.1.4",
         "graphql": "^15.5.3",
         "next": "latest",
         "react": "^17.0.2",
@@ -6639,6 +6640,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "node_modules/fuzzysort": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.1.4.tgz",
+      "integrity": "sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -16676,6 +16682,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "fuzzysort": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.1.4.tgz",
+      "integrity": "sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "@emotion/styled": "11.1.5",
     "formik": "^2.2.9",
     "framer-motion": "^4.0.3",
+    "fuzzysort": "^1.1.4",
     "graphql": "^15.5.3",
     "next": "latest",
     "react": "^17.0.2",

--- a/web/src/components/CreateStudentModal.tsx
+++ b/web/src/components/CreateStudentModal.tsx
@@ -1,9 +1,10 @@
-import { Box, Button, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Select, useToast, FormControl, FormLabel, Input, FormErrorMessage } from '@chakra-ui/react'
+import { Box, Button, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, useToast, FormControl, FormLabel, Input, FormErrorMessage } from '@chakra-ui/react'
 import { Field, Form, Formik } from 'formik'
 
 import { StudentCreateErrorCode, useCreateStudentMutation, useTutoriumsQuery } from '../generated/graphql'
 import { toastApolloError } from '../util'
 import React, { useMemo } from 'react'
+import { SearchSelectInputSingle } from './SearchSelectInput'
 
 interface Props {
   isOpen: boolean,
@@ -102,18 +103,14 @@ export const CreateStudentModal: React.FC<Props> = ({ isOpen, onClose }) => {
                     )}
                 </Field>
                 <Box mt={4} />
-                <Field name="tutoriumId">
-                    {({ field }) => (
-                        <FormControl id="tutoriumId">
-                            <FormLabel>Tutorium (optional)</FormLabel>
-                            <Select {...field} placeholder="Kein Tutorium">
-                                {data.map(tutorium => {
-                                  return <option value={tutorium.id} key={tutorium.id}> {tutorium.name}</option>
-                                })}
-                            </Select>
-                        </FormControl>
-                    )}
-                </Field>
+                <SearchSelectInputSingle
+                  label="Tutorium (optional)"
+                  name="tutoriumId"
+                  placeholder="Kein Tutorium gewählt"
+                  items={data}
+                  textTransformer={t => t.name}
+                  valueTransformer={t => t.id}
+                />
               </ModalBody>
               <ModalFooter>
                 <Button mr={3} variant="ghost" onClick={onClose}>Abbrechen</Button>

--- a/web/src/components/CreateTutoriumModal.tsx
+++ b/web/src/components/CreateTutoriumModal.tsx
@@ -8,7 +8,7 @@ import {
   ModalHeader,
   ModalOverlay,
   useToast,
-  Select,
+  Box,
   FormControl,
   FormLabel,
   Input,
@@ -19,6 +19,7 @@ import { TutoriumCreateErrorCode, useCreateTutoriumMutation, useTeachersQuery } 
 import { toastApolloError } from '../util'
 
 import React, { useMemo } from 'react'
+import { SearchSelectInputSingle } from './SearchSelectInput'
 
 interface Props {
   isOpen: boolean,
@@ -118,20 +119,16 @@ export const CreateTutoriumModal: React.FC<Props> = ({ isOpen, onClose }) => {
                     </FormControl>
                   )}
                 </Field>
-                <FormLabel>Name des Tutors</FormLabel>
-                <Field name="tutorId" validate={validateTutorId}>
-                  {({ field, form }) => (
-                    <FormControl isInvalid={form.errors.tutorId && form.touched.tutorId}>
-                      <Select {...field} placeholder="Wähle einen Lehrer">
-                        {teachersData.map(currentUser =>
-                          (
-                            <option id="tutorId" value={currentUser.id} key={currentUser.id}> {currentUser.name} </option>
-                          ))}
-                      </Select>
-                      <FormErrorMessage>{form.errors.tutorId}</FormErrorMessage>
-                    </FormControl>
-                  )}
-                </Field>
+                <Box mt={4} />
+                <SearchSelectInputSingle
+                  name="tutorId"
+                  label="Name des Tutors"
+                  items={teachersData}
+                  valueTransformer={t => t.id}
+                  textTransformer={t => t.name}
+                  validate={validateTutorId}
+                  placeholder="Wähle einen Lehrer"
+                />
               </ModalBody>
               <ModalFooter>
                 <Button mr={3} variant="ghost" onClick={onClose}>Abbrechen</Button>

--- a/web/src/components/EditStudentModal.tsx
+++ b/web/src/components/EditStudentModal.tsx
@@ -1,9 +1,10 @@
-import { Box, Button, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Select, useToast, FormControl, FormLabel, Input, FormErrorMessage } from '@chakra-ui/react'
+import { Box, Button, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, useToast, FormControl, FormLabel, Input, FormErrorMessage } from '@chakra-ui/react'
 import { Field, Form, Formik } from 'formik'
 
 import { StudentEditErrorCode, useEditStudentMutation, useTutoriumsQuery } from '../generated/graphql'
 import { toastApolloError } from '../util'
 import React, { useMemo } from 'react'
+import { SearchSelectInputSingle } from './SearchSelectInput'
 
 interface Props {
   isOpen: boolean,
@@ -106,18 +107,14 @@ export const EditStudentModal: React.FC<Props> = ({ isOpen, onClose, studentId, 
                     )}
                 </Field>
                 <Box mt={4} />
-                <Field name="tutorium">
-                    {({ field }) => (
-                        <FormControl id="tutorium">
-                            <FormLabel>Tutorium (optional)</FormLabel>
-                            <Select {...field} placeholder="Kein Tutorium">
-                                {data.map(tutorium => {
-                                  return <option value={tutorium.id} key={tutorium.id}> {tutorium.name}</option>
-                                })}
-                            </Select>
-                        </FormControl>
-                    )}
-                </Field>
+                <SearchSelectInputSingle
+                  label="Tutorium (optional)"
+                  name="tutorium"
+                  placeholder="Kein Tutorium gewählt"
+                  items={data}
+                  textTransformer={t => t.name}
+                  valueTransformer={t => t.id}
+                />
               </ModalBody>
               <ModalFooter>
                 <Button mr={3} variant="ghost" onClick={onClose}>Abbrechen</Button>

--- a/web/src/components/SearchSelectInput.tsx
+++ b/web/src/components/SearchSelectInput.tsx
@@ -1,0 +1,108 @@
+import { FormControl, Input, FormLabel, FormErrorMessage, InputGroup, InputRightElement, Tag, Text } from '@chakra-ui/react'
+import React from 'react'
+import SearchSelectModal, { useSearchSelectModal } from './SearchSelectModal'
+import { FieldHookConfig, useField } from 'formik'
+import { ExternalLinkIcon } from '@chakra-ui/icons'
+
+interface SearchSelectInputProps<T> {
+  placeholder?: string
+  items: T[]
+
+  valueTransformer: (t: T) => string
+  textTransformer: (t: T) => string
+
+  name: string
+  label: string
+}
+
+export function SearchSelectInputSingle<T> (props: SearchSelectInputProps<T> & FieldHookConfig<string>): JSX.Element {
+  const { items, textTransformer, placeholder = 'Kein Objekt gewählt', valueTransformer, label, name } = props
+  const [, meta, helpers] = useField(props)
+
+  const objectByValue = (v: string) => items.find(item => valueTransformer(item) === v)
+
+  const handleChange = (v: string[]) => {
+    console.log(v)
+    helpers.setValue(v.length === 0 ? '' : v[0])
+  }
+
+  const searchSelectModal = useSearchSelectModal<T>({
+    value: meta.value != null && meta.value !== '' ? [meta.value] : [],
+    items,
+    textTransformer,
+    valueTransformer,
+    selectMultiple: false,
+    handleChange
+  })
+
+  const activateModal = () => {
+    searchSelectModal.onOpen()
+    helpers.setTouched(true)
+  }
+
+  return (
+    <>
+      <FormControl id={name} isInvalid={meta.touched && meta.error != null}>
+        <FormLabel>{label}</FormLabel>
+        <InputGroup onFocus={activateModal} onClick={activateModal} >
+          <Input isReadOnly value={searchSelectModal.selection.length === 0 ? '' : textTransformer(objectByValue(searchSelectModal.selection[0]))} placeholder={placeholder} />
+          <InputRightElement>
+            <ExternalLinkIcon />
+          </InputRightElement>
+        </InputGroup>
+        <FormErrorMessage>{meta.error}</FormErrorMessage>
+      </FormControl>
+      <SearchSelectModal {...searchSelectModal} />
+    </>
+  )
+}
+
+export function SearchSelectInputMultiple<T> (props: SearchSelectInputProps<T> & FieldHookConfig<Array<String>>): JSX.Element {
+  const { items, textTransformer, valueTransformer, placeholder = 'Keine Objekt gewählt', label, name } = props
+  const [, meta, helpers] = useField(props.name)
+
+  const objectByValue = (v: string) => items.find(item => valueTransformer(item) === v)
+
+  const handleChange = (v: string[]) => {
+    console.log(v)
+    helpers.setValue(v)
+  }
+
+  const searchSelectModal = useSearchSelectModal<T>({
+    value: meta.value != null && Array.isArray(meta.value) ? meta.value : [],
+    items,
+    textTransformer,
+    valueTransformer,
+    selectMultiple: true,
+    handleChange
+  })
+
+  const activateModal = () => {
+    searchSelectModal.onOpen()
+    helpers.setTouched(true)
+  }
+
+  return (
+    <>
+      <FormControl id={name} isInvalid={meta.touched && meta.error != null}>
+        <FormLabel>{label}</FormLabel>
+        <InputGroup onFocus={(e) => { activateModal(); e.target.blur() }} onClick={activateModal} >
+          <Input as="div" w="xs" h="auto" minH={20} p={2}>
+            {searchSelectModal.selection.length === 0 &&
+              <Text color="gray">{placeholder}</Text>
+            }
+            {searchSelectModal.selection.map(objectByValue).map(textTransformer).map(text => (
+              <Tag key={text} m={1}>{text}</Tag>
+            ))}
+
+          </Input>
+          <InputRightElement>
+            <ExternalLinkIcon />
+          </InputRightElement>
+        </InputGroup>
+        <FormErrorMessage>{meta.error}</FormErrorMessage>
+      </FormControl>
+      <SearchSelectModal {...searchSelectModal} />
+    </>
+  )
+}

--- a/web/src/components/SearchSelectModal.tsx
+++ b/web/src/components/SearchSelectModal.tsx
@@ -1,0 +1,159 @@
+import { CheckIcon, SearchIcon } from '@chakra-ui/icons'
+import { Text, Box, Modal, ModalContent, ModalHeader, ModalOverlay, ModalCloseButton, ModalBody, ModalFooter, Button, Input, InputGroup, InputLeftElement, Flex, Spacer, Tag, TagCloseButton, TagLabel, InputRightElement, useDisclosure } from '@chakra-ui/react'
+import React, { useState } from 'react'
+import fuzzysort from 'fuzzysort'
+import { AnimatePresence, motion } from 'framer-motion'
+
+const MotionBox = motion(Box)
+
+interface SearchSelectModalProps<T> {
+    value: string[]
+    items: T[]
+    textTransformer: (t: T) => string
+    valueTransformer: (t: T) => string
+    selectMultiple?: boolean
+    isOpen: boolean,
+    onOpen: () => void,
+    onClose: () => void,
+    selection: string[],
+    setSelection: ((f:(prevSelection: string[]) => string[]) => void)
+    handleChange: (t: string[]) => void
+}
+
+export function useSearchSelectModal<T> (options: Pick<SearchSelectModalProps<T>, 'value' | 'items' | 'textTransformer' | 'selectMultiple' | 'handleChange' | 'valueTransformer'>) {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [selection, setSelection] = useState<string[]>(options.value)
+
+  const { handleChange = () => {} } = options
+
+  return {
+    ...options,
+    isOpen,
+    onOpen,
+    onClose,
+    selection,
+    setSelection: (f:(prevSelection: string[]) => string[]) => { setSelection((ids) => { const v = f(ids); handleChange(v); return v }) }
+  }
+}
+
+function SearchSelectModal<T> ({ items = [], textTransformer, valueTransformer, selectMultiple, selection, setSelection, isOpen, onClose }: SearchSelectModalProps<T>): JSX.Element {
+  const [search, setSearch] = useState('')
+  const [tempSelection, setTempSelection] = useState<T[]>([])
+
+  const handleSearchChange = event => setSearch(event.target.value)
+
+  const objectByValue = (v: string) => items.find(item => valueTransformer(item) === v)
+
+  const saveChanges = () => {
+    setSelection(() => tempSelection.map((v) => valueTransformer(v)))
+    setSearch('')
+  }
+
+  const revertChanges = () => {
+    setTempSelection(() => selection.map(value => objectByValue(value)))
+    setSearch('')
+  }
+
+  const removeSelection = (t: T) => { setTempSelection(tempSelection => selectMultiple ? tempSelection.filter(v => v !== t) : []) }
+  const select = (t: T) => setTempSelection(
+    tempSelection => selectMultiple
+      ? tempSelection.includes(t)
+        ? tempSelection.filter(v => v !== t)
+        : tempSelection.concat(t)
+      : tempSelection.includes(t)
+        ? []
+        : [t])
+
+  const searchables = items.map(t => ({ object: t, text: textTransformer(t) }))
+  const results = fuzzysort.go(search, searchables, {
+    key: 'text'
+  })
+
+  const itemsToDisplay = search.length === 0
+    ? items
+    : results.map(r => r.obj.object)
+
+  return (
+    <Modal isOpen={isOpen} onClose={() => { revertChanges(); onClose() }}>
+      <motion.div transition={{}}/>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Auswahl</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <InputGroup marginBottom={2}>
+            <InputLeftElement>
+              <SearchIcon />
+            </InputLeftElement>
+            <Input value={search} onChange={handleSearchChange} variant="filled" />
+            <InputRightElement>
+              <TagCloseButton onClick={() => { setSearch('') }} />
+            </InputRightElement>
+          </InputGroup>
+          {items.length === 0 &&
+            <Flex h="md" padding={2} justifyContent="center">
+              <Text mt={4}>Keine Elemente zur Auswahl verfügbar.</Text>
+            </Flex>
+          }
+          {items.length !== 0 &&
+            <Box h="md" overflowY="scroll" padding={2}>
+              <Flex direction="column">
+                <AnimatePresence initial={true}>
+                  {itemsToDisplay.map((t) => (
+                    <MotionBox
+                      key={textTransformer(t)}
+                      w="full"
+
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{
+                        duration: 0.2,
+                        ease: 'easeInOut'
+                      }}
+                    >
+                      <Button isActive={tempSelection.includes(t)} onClick={
+                        () => select(t)
+                      }
+                        variant="ghost" justifyContent="flex-start" my={0.5} w="full">
+                        {textTransformer(t)}
+                        <Spacer />
+                        {tempSelection.includes(t) &&
+                          <CheckIcon color="primary.400" mr={2} />
+                        }
+                      </Button>
+                    </MotionBox>
+                  ))}
+                </ AnimatePresence>
+              </Flex>
+            </Box>
+          }
+        </ModalBody>
+        <ModalFooter bg="gray.100" borderBottomRadius="md">
+          <>
+            <Flex wrap="wrap">
+              <Text w="full" mr={2}>
+                {selectMultiple && (tempSelection.length === 0 ? '' : `Ausgewählt (${tempSelection.length}):`)}
+                {!selectMultiple && (tempSelection.length === 0 ? '' : 'Ausgewählt:')}
+              </Text>
+              {tempSelection.map((t) => (
+                <Tag key={textTransformer(t)} my={1} mr={1} colorScheme="primary">
+                  <TagLabel>{textTransformer(t)}</TagLabel>
+                  <TagCloseButton onClick={() => removeSelection(t)}/>
+                </Tag>
+              ))}
+            </Flex>
+            <Spacer />
+          </>
+
+          <Flex>
+            <Button variant="ghost" colorScheme="gray" onClick={() => { revertChanges(); onClose() }}>Abbrechen</Button>
+            <Button colorScheme="primary" onClick={() => { saveChanges(); onClose() }}>Auswählen</Button>
+          </Flex>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default SearchSelectModal

--- a/web/src/pages/absence.tsx
+++ b/web/src/pages/absence.tsx
@@ -6,12 +6,13 @@ import {
   FormControl,
   FormErrorMessage,
   FormLabel,
-  Input, Switch
+  Input, Switch,
+  Flex, Box
 } from '@chakra-ui/react'
 import { Field, Form, Formik } from 'formik'
 import { formatDateISO } from '../util'
-import { Flex } from '@chakra-ui/layout'
-import { useCreateAbsencesMutation } from '../generated/graphql'
+import { useCreateAbsencesMutation, useStudentsQuery } from '../generated/graphql'
+import { SearchSelectInputMultiple } from '../components/SearchSelectInput'
 
 interface Props extends WithAuthProps {
 }
@@ -23,6 +24,7 @@ const AbsencePage: React.FC<Props> = ({ self }) => {
     lessonIndexes.push(i)
   }
 
+  const studentsQuery = useStudentsQuery()
   const [createAbsences] = useCreateAbsencesMutation()
 
   return (
@@ -82,19 +84,15 @@ const AbsencePage: React.FC<Props> = ({ self }) => {
                 </FormControl>
               )}
             </Field>
-            <Field name="students">
-              {({ field, form }) => (
-                <FormControl isInvalid={form.errors.students && form.touched.students} mb={6}>
-                  <FormLabel>Schüler</FormLabel>
-                  <CheckboxGroup>
-                    <Flex direction="column">
-                      <Checkbox {...field} key="ad07c79e-7d96-46dd-9cdf-8fccae1ba75b" value="ad07c79e-7d96-46dd-9cdf-8fccae1ba75b">Heinz Müller</Checkbox>
-                    </Flex>
-                  </CheckboxGroup>
-                  <FormErrorMessage>{form.errors.students}</FormErrorMessage>
-                </FormControl>
-              )}
-            </Field>
+            <SearchSelectInputMultiple
+              name="students"
+              label="Schüler"
+              items={studentsQuery.data?.students}
+              textTransformer={t => `${t.lastName}, ${t.firstName}`}
+              valueTransformer={t => t.id}
+              placeholder={'Keine Schüler gewählt'}
+            />
+            <Box mb={4} />
             <Button colorScheme="primary" type="submit" isLoading={props.isSubmitting}>Weiter</Button>
           </Form>
         )}


### PR DESCRIPTION
Resolves #71 This change implements a new type of input that can be used to select items out of a large list.  It has a search bar to filter the selection possibilities. It implements the Formik Field type, meaning you can use it very easily in Formik fields, without further crud. It comes in 2 versions, one for selecting single items and one for multiple. 

I swapped it in for the existing inputs where applicable, so you can use that as a reference for using the input.

![Input](https://user-images.githubusercontent.com/22642478/143567994-424ddb48-f0f4-4475-a3f8-80aed901393d.png)
![Modal](https://user-images.githubusercontent.com/22642478/143568092-2b4bf1d0-ef44-4aac-8d07-55016611493c.png)
![Selection](https://user-images.githubusercontent.com/22642478/143568207-5dbfa21c-fa83-456d-b92f-4355420d9a35.png)
![Search](https://user-images.githubusercontent.com/22642478/143568344-6c5514e7-5b46-445a-a438-db44b62c4344.png)