### PR TITLE
Fixed bug related to #80 that broke /login page

### DIFF
--- a/web/src/components/withAuth.tsx
+++ b/web/src/components/withAuth.tsx
@@ -40,7 +40,7 @@ const WithAuth = (Component: React.FC<WithAuthProps>, options?: Options) => {
           </Center>
         )}
         {!loading && isAuthorized(data, roles) === !redirectAuthorized && (
-          <Component self={data.self} />
+          <Component self={data?.self} />
         )}
       </>
     )


### PR DESCRIPTION
Now that self can return a standard graphql error, data could sometimes be null, meaning the use of data.self lead to an error.